### PR TITLE
Some minor tweaks

### DIFF
--- a/src/proximity.jl
+++ b/src/proximity.jl
@@ -46,7 +46,7 @@ julia> minimum_distance(p, q, dir)
 """
 function minimum_distance(p::Any, q::Any, init_dir::SVector{D, T}; max_iter=100, atol::T=sqrt(eps(T))*oneunit(T)) where {D, T}
     collision, dir, psimplex, qsimplex, sz = gjk(p, q, init_dir, max_iter, atol, minimum_distance_cond)
-    return collision ? 0.0 : norm(dir)
+    return collision ? zero(eltype(dir)) : norm(dir)
 end
 
 """
@@ -144,7 +144,7 @@ function tolerance_verification_cond(dir::SVector, collision::Bool, tv)
     tv > norm(dir) ? true : collision
 end
 
-@generated function check_degeneracy(simplex::SMatrix{N, M, T}, s::SVector{N, T}, sz::Vararg{Int, 1}) where {N, M, T}
+@generated function check_degeneracy(simplex::SMatrix{N, M, T}, s::StaticVector{N, T}, sz::Vararg{Int, 1}) where {N, M, T}
     exprs = :(false)
     for i = 1:M
         exprs = :($i > sz[1] ? $exprs : ($exprs || norm(simplex[:, $i] - s) ≤ eps($T)*oneunit($T)))

--- a/src/simplex.jl
+++ b/src/simplex.jl
@@ -7,7 +7,7 @@ function proj(u::AbstractVector, v::AbstractVector)
     (u ⋅ v)/(u ⋅ u)*u
 end
 
-@generated function insertcolumn(s::SVector{N, T}) where {N, T}
+@generated function insertcolumn(s::StaticVector{N, T}) where {N, T}
     S = (N, N+1)
     exprs = Array{Expr}(undef, S)
     itr = [1:n for n = S]
@@ -22,7 +22,7 @@ end
     end
 end
 
-@generated function insertcolumn(simplex::SMatrix{N, M, T}, s::SVector{N, T}, idx::Vararg{Int, 1}) where {N, M, T}
+@generated function insertcolumn(simplex::SMatrix{N, M, T}, s::StaticVector{N, T}, idx::Vararg{Int, 1}) where {N, M, T}
     S = (N, M)
     exprs = Array{Expr}(undef, S)
     itr = [1:n for n = S]


### PR DESCRIPTION
- Loosen method argument types to accomodate `StaticVector`s other than `SVector`.
- Small fix for dimensional correctness and type stability.

With these changes I'm able to use a type like `Point <: StaticArrays.FieldVector` and the dimensional correctness fix seemed necessary for what I described in https://github.com/arlk/CurveProximityQueries.jl/pull/7. 